### PR TITLE
Add error when the quantity is negative in create ingredient api

### DIFF
--- a/WarehouseService/src/main/kotlin/application/WarehouseServiceImpl.kt
+++ b/WarehouseService/src/main/kotlin/application/WarehouseServiceImpl.kt
@@ -14,8 +14,12 @@ class WarehouseServiceImpl(mongoInfo: MongoInfo) : WarehouseService {
     }
 
     override suspend fun createIngredient(ingredient: Ingredient): WarehouseServiceResponse<Ingredient> {
-        val repositoryRes = repository.createIngredient(ingredient.name, ingredient.quantity)
-        return WarehouseServiceResponse(repositoryRes.data, repositoryRes.message)
+        return if (ingredient.quantity > 0) {
+            val repositoryRes = repository.createIngredient(ingredient.name, ingredient.quantity)
+            WarehouseServiceResponse(repositoryRes.data, repositoryRes.message)
+        } else {
+            WarehouseServiceResponse(null, WarehouseMessage.ERROR_WRONG_PARAMETERS)
+        }
     }
 
     override suspend fun updateConsumedIngredientsQuantity(ingredients: List<UpdateQuantity>): WarehouseServiceResponse<List<Ingredient>> {

--- a/WarehouseService/src/test/kotlin/repository/features/warehouse.feature
+++ b/WarehouseService/src/test/kotlin/repository/features/warehouse.feature
@@ -7,6 +7,7 @@ Feature: Interacting with the warehouse
     Examples:
       |name     |quantity |response | message                          |
       |milk     |99       |400      | ERROR_INGREDIENT_ALREADY_EXISTS  |
+      |butter   |-2       |400      | ERROR_WRONG_PARAMETERS            |
       |coffee   |5        |200      | OK                               |
 
   Scenario Outline: Manager wants to restock the <name> in the warehouse

--- a/WarehouseService/src/test/kotlin/server/RoutesTester.kt
+++ b/WarehouseService/src/test/kotlin/server/RoutesTester.kt
@@ -31,6 +31,7 @@ class RoutesTester : BaseTest() {
     suspend fun createIngredientRouteTest() {
         val newIngredient = Json.encodeToString(coffee)
         val existingIngredient = Json.encodeToString(milk)
+        val wrongIngredient = Ingredient("butter", -2)
 
         var response = apiUtils.createIngredient(Buffer.buffer(newIngredient)).coAwait()
         response.statusCode() shouldBe HttpURLConnection.HTTP_OK
@@ -49,6 +50,10 @@ class RoutesTester : BaseTest() {
         response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
 
         response = apiUtils.createIngredient(Buffer.buffer("")).coAwait()
+        response.statusCode() shouldBe HttpURLConnection.HTTP_BAD_REQUEST
+        response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
+
+        response = apiUtils.createIngredient(Buffer.buffer(Json.encodeToString(wrongIngredient))).coAwait()
         response.statusCode() shouldBe HttpURLConnection.HTTP_BAD_REQUEST
         response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
     }


### PR DESCRIPTION
## Add error when the quantity is negative in create ingredient api

## Checks before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core fix, I have added tests.
- [ ] If it is a front-end feature, I have manually tested it.
- [x] I have added detailed documentation to my code.

## Summary

Fixed create ingredient api: if the quantity passed in the body is less or equal to 0, the api returns ERROR_WRONG_PARAMETERS.
