### PR TITLE
Add error when the quantity is negative in restock api

### DIFF
--- a/WarehouseService/src/main/kotlin/application/WarehouseService.kt
+++ b/WarehouseService/src/main/kotlin/application/WarehouseService.kt
@@ -31,7 +31,9 @@ interface WarehouseService {
 
     /**
      * @param ingredient information needed to restock
-     * @return the repository response
+     * @return null and WarehouseMessage.ERROR_WRONG_PARAMETERS
+     *      if the quantity passed in the body is less ore equal to 0,
+     *      otherwise it returns the repository response
      */
     suspend fun restock(ingredient: UpdateQuantity): WarehouseServiceResponse<Ingredient>
 

--- a/WarehouseService/src/main/kotlin/application/WarehouseService.kt
+++ b/WarehouseService/src/main/kotlin/application/WarehouseService.kt
@@ -12,7 +12,9 @@ interface WarehouseService {
 
     /**
      * @param ingredient to create
-     * @return the repository response
+     * @return null and WarehouseMessage.ERROR_WRONG_PARAMETERS
+     *      if the quantity passed in the body is less ore equal to 0,
+     *      otherwise it returns the repository response
      */
     suspend fun createIngredient(ingredient: Ingredient): WarehouseServiceResponse<Ingredient>
 
@@ -21,9 +23,9 @@ interface WarehouseService {
      * @return the list of updated ingredients and WarehouseMessage.OK
      *      if all the consumed ingredients are updated,
      *      null and WarehouseMessage.ERROR_INGREDIENT_QUANTITY
-     *          if a quantity is greater than the actual quantity of the consumed ingredient in the warehouse,
+     *      if a quantity is greater than the actual quantity of the consumed ingredient in the warehouse,
      *      null and WarehouseMessage.ERROR_INGREDIENT_NOT_FOUND
-     *          if one consumed ingredient is not found in the warehouse
+     *      if one consumed ingredient is not found in the warehouse
      */
     suspend fun updateConsumedIngredientsQuantity(ingredients: List<UpdateQuantity>): WarehouseServiceResponse<List<Ingredient>>
 

--- a/WarehouseService/src/main/kotlin/application/WarehouseServiceImpl.kt
+++ b/WarehouseService/src/main/kotlin/application/WarehouseServiceImpl.kt
@@ -42,8 +42,12 @@ class WarehouseServiceImpl(mongoInfo: MongoInfo) : WarehouseService {
     }
 
     override suspend fun restock(ingredient: UpdateQuantity): WarehouseServiceResponse<Ingredient> {
-        val repositoryRes = repository.restock(ingredient.name, ingredient.quantity)
-        return WarehouseServiceResponse(repositoryRes.data, repositoryRes.message)
+        return if (ingredient.quantity > 0) {
+            val repositoryRes = repository.restock(ingredient.name, ingredient.quantity)
+            WarehouseServiceResponse(repositoryRes.data, repositoryRes.message)
+        } else {
+            WarehouseServiceResponse(null, WarehouseMessage.ERROR_WRONG_PARAMETERS)
+        }
     }
 
     override suspend fun getAllAvailableIngredients(): WarehouseServiceResponse<List<Ingredient>> {

--- a/WarehouseService/src/test/kotlin/BaseTest.kt
+++ b/WarehouseService/src/test/kotlin/BaseTest.kt
@@ -8,6 +8,7 @@ open class BaseTest : AnnotationSpec() {
     protected val milk = Ingredient("milk", 99)
     protected val tea = Ingredient("tea", 4)
     protected val coffee = Ingredient("coffee", 1)
+    protected val butter = Ingredient("butter", -2)
     protected val notAvailableCoffee = Ingredient(coffee.name, 0)
     protected val ingredients = listOf(milk, tea)
 

--- a/WarehouseService/src/test/kotlin/repository/features/warehouse.feature
+++ b/WarehouseService/src/test/kotlin/repository/features/warehouse.feature
@@ -17,6 +17,7 @@ Feature: Interacting with the warehouse
     Examples:
       |name   |quantity |response | message                    |
       |coffee |10       |404      | ERROR_INGREDIENT_NOT_FOUND |
+      |butter |-2       |400      | ERROR_WRONG_PARAMETERS |
       |tea    |5        |200      | OK                         |
 
   Scenario Outline: System wants to decrease the <name> quantity in the warehouse

--- a/WarehouseService/src/test/kotlin/server/RoutesTester.kt
+++ b/WarehouseService/src/test/kotlin/server/RoutesTester.kt
@@ -31,7 +31,6 @@ class RoutesTester : BaseTest() {
     suspend fun createIngredientRouteTest() {
         val newIngredient = Json.encodeToString(coffee)
         val existingIngredient = Json.encodeToString(milk)
-        val wrongIngredient = Ingredient("butter", -2)
 
         var response = apiUtils.createIngredient(Buffer.buffer(newIngredient)).coAwait()
         response.statusCode() shouldBe HttpURLConnection.HTTP_OK
@@ -53,7 +52,7 @@ class RoutesTester : BaseTest() {
         response.statusCode() shouldBe HttpURLConnection.HTTP_BAD_REQUEST
         response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
 
-        response = apiUtils.createIngredient(Buffer.buffer(Json.encodeToString(wrongIngredient))).coAwait()
+        response = apiUtils.createIngredient(Buffer.buffer(Json.encodeToString(butter))).coAwait()
         response.statusCode() shouldBe HttpURLConnection.HTTP_BAD_REQUEST
         response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
     }
@@ -108,6 +107,7 @@ class RoutesTester : BaseTest() {
     @Test
     suspend fun restockRouteTest() {
         val quantity = Buffer.buffer(Json.encodeToString(Quantity(10)))
+
         apiUtils.restock("tea", quantity).coAwait().statusCode() shouldBe HttpURLConnection.HTTP_OK
 
         var response = apiUtils.restock("coffee", quantity).coAwait()
@@ -119,6 +119,10 @@ class RoutesTester : BaseTest() {
         response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
 
         response = apiUtils.restock("tea", Buffer.buffer("[{\"quantiti\": \"ten\"}]")).coAwait()
+        response.statusCode() shouldBe HttpURLConnection.HTTP_BAD_REQUEST
+        response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
+
+        response = apiUtils.restock("tea", Buffer.buffer(Json.encodeToString(butter))).coAwait()
         response.statusCode() shouldBe HttpURLConnection.HTTP_BAD_REQUEST
         response.statusMessage() shouldBe WarehouseMessage.ERROR_WRONG_PARAMETERS.toString()
     }


### PR DESCRIPTION
##  Add error when the quantity is negative in restock api

## Checks before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core fix, I have added tests.
- [ ] If it is a front-end feature, I have manually tested it.
- [x] I have added detailed documentation to my code.

## Summary
Fixed restock api: if the quantity passed in the body is less or equal to 0, the api returns ERROR_WRONG_PARAMETERS.
