### PR TITLE
Change order jobs execution

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,23 +15,22 @@ jobs:
     name: check format ts
     uses: ./.github/workflows/ts_format_check_pipeline.yml
 
-  serverTest:
-    needs:
-      - tsFormatCheck
-    name: test server
-    uses: ./.github/workflows/server_test_pipeline.yml
-
   menuAndOrdersServiceTest:
     needs:
-      - serverTest
       - tsFormatCheck
     name: test menu-service and orders-service
     uses: ./.github/workflows/menu_and_orders_service_test_pipeline.yml
 
   kotlinTest:
     needs:
-      - menuAndOrdersServiceTest
-      - serverTest
       - spotlessCheck
     name: test WarehouseService
     uses: ./.github/workflows/warehouse_service_pipeline.yml
+
+  serverTest:
+    needs:
+      - tsFormatCheck
+      - kotlinTest
+      - menuAndOrdersServiceTest
+    name: test server
+    uses: ./.github/workflows/server_test_pipeline.yml


### PR DESCRIPTION
## Change order jobs execution

## Summary
Change order jobs execution: before executing server tests, that requires all the microservices to be active, we execute their tests.
